### PR TITLE
fix: remove strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"access": "public"
 	},
 	"scripts": {
-		"lint": "eslint ."
+		"lint": "eslint .",
+		"test": "pnpm run -r test"
 	},
 	"husky": {
 		"hooks": {

--- a/packages/base/rules/errors.js
+++ b/packages/base/rules/errors.js
@@ -1,9 +1,5 @@
 module.exports = {
 	rules: {
-
-		// babel inserts `'use strict';` for us
-		strict: ['error', 'never'],
-
 		// Enforce “for” loop update clause moving the counter in the right direction
 		// https://eslint.org/docs/rules/for-direction
 		'for-direction': 'error',


### PR DESCRIPTION
Removing [strict](https://eslint.org/docs/rules/strict) as a patch because it's hard to determine whether a file is a raw Node module or compiled by Webpack/rollup (which adds strict mode).

